### PR TITLE
Serve master.cfg from a config nginx service

### DIFF
--- a/config/master.cfg
+++ b/config/master.cfg
@@ -1,0 +1,1 @@
+../master.cfg

--- a/multimaster/docker-compose.yml
+++ b/multimaster/docker-compose.yml
@@ -14,12 +14,17 @@ services:
       - 8080:8080
       - 9989:9989   # for external workers
 
+  config:
+    image: nginx
+    volumes:
+      - ./config:/usr/share/nginx/html:ro
+
   buildbot:
     image: buildbot/buildbot-master:latest
     env_file: db.env
     environment:
         - BUILDBOT_CONFIG_DIR=config
-        - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
+        - BUILDBOT_CONFIG_URL=http://config/master.cfg
         - BUILDBOT_WORKER_PORT=9989
         - BUILDBOT_WEB_URL=http://localhost:8080/
         - BUILDBOT_WEB_PORT=8080
@@ -28,6 +33,7 @@ services:
         - BUILDBOT_MQ_REALM=realm1
         - TCP_PORTS=8080,9989
     links:
+      - config:config
       - db
     expose:
         - 8080

--- a/simple/docker-compose.yml
+++ b/simple/docker-compose.yml
@@ -1,18 +1,25 @@
 version: '2'
 services:
+  config:
+    image: nginx
+    volumes:
+      - ./config:/usr/share/nginx/html:ro
+
   buildbot:
     image: buildbot/buildbot-master:master
     env_file:
         - db.env
     environment:
         - BUILDBOT_CONFIG_DIR=config
-        - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
+        - BUILDBOT_CONFIG_URL=http://config/master.cfg
         - BUILDBOT_WORKER_PORT=9989
         - BUILDBOT_WEB_URL=http://localhost:8080/
         - BUILDBOT_WEB_PORT=8080
     links:
+      - config:config
       - db
     depends_on:
+      - config:config
       - db
     ports:
       - "8080:8080"


### PR DESCRIPTION
I'm mainly submitting this PR to get a discussion going about a different way to handle serving `master.cfg` in the [Buildbot tutorial with Docker](https://docs.buildbot.net/latest/tutorial/docker.html).

The current tutorial requires users to create a completely separate repository for the `master.cfg` file, push it to GitHub, then tweak their `docker-compose.yml` files to point to the `master.tar.gz` file in that repository.

That's a lot of steps, and I think it could be much easier if you just have the user fire up a `config` service that servers the user's local `master.cfg` file to the Buildbot master. This PR enables this behavior. If the user updates `master.cfg` they just have to restart the services for the change to take effect, instead of switching to a different repo, making the change, committing the change, pushing the change, and restarting the services.

This PR does not update the tutorial. The `config` service is just an `nginx` server, and is configured exactly how the official nginx Docker repository suggests. There is no authentication for downloading the `master.cfg` file from the `config` service, but the fact that it runs in the same docker network as the rest of the current services and doesn't require the user to make their `master.cfg` configuration file public is a security **and** usability win in my book.

This eases the learning curve to getting a Buildbot server up and running, and gives the user hints as to how to host the configuration file "for real" if they need to scale up.

Even easier than this would be to share the config directory on the host with the master service and use a `file://` URL to point to the config file, but that might complicate more things.

Your thoughts?