### PR TITLE
changed web port to 8010 to match bbdocs

### DIFF
--- a/simple/docker-compose.yml
+++ b/simple/docker-compose.yml
@@ -8,14 +8,14 @@ services:
         - BUILDBOT_CONFIG_DIR=config
         - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
         - BUILDBOT_WORKER_PORT=9989
-        - BUILDBOT_WEB_URL=http://localhost:8080/
-        - BUILDBOT_WEB_PORT=8080
+        - BUILDBOT_WEB_URL=http://localhost:8010/
+        - BUILDBOT_WEB_PORT=8010
     links:
       - db
     depends_on:
       - db
     ports:
-      - "8080:8080"
+      - "8010:8010"
   db:
     env_file:
         - db.env


### PR DESCRIPTION
Created a PR to change the bbdocs it was said it would be better to use the de-facto standard port of 8010. This would fix the discrepancy between the docs and the docker compose file. 