### PR TITLE
docker-compose.yml: Sanitize whitespace usage

### DIFF
--- a/simple/docker-compose.yml
+++ b/simple/docker-compose.yml
@@ -3,13 +3,13 @@ services:
   buildbot:
     image: buildbot/buildbot-master:master
     env_file:
-        - db.env
+      - db.env
     environment:
-        - BUILDBOT_CONFIG_DIR=config
-        - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
-        - BUILDBOT_WORKER_PORT=9989
-        - BUILDBOT_WEB_URL=http://localhost:8080/
-        - BUILDBOT_WEB_PORT=8080
+      - BUILDBOT_CONFIG_DIR=config
+      - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
+      - BUILDBOT_WORKER_PORT=9989
+      - BUILDBOT_WEB_URL=http://localhost:8080/
+      - BUILDBOT_WEB_PORT=8080
     links:
       - db
     depends_on:
@@ -18,19 +18,19 @@ services:
       - "8080:8080"
   db:
     env_file:
-        - db.env
+      - db.env
     image: "postgres:9.4"
     expose:
-        - 5432
+      - 5432
 
   worker:
     image: "buildbot/buildbot-worker:master"
     environment:
-        BUILDMASTER: buildbot
-        BUILDMASTER_PORT: 9989
-        WORKERNAME: example-worker
-        WORKERPASS: pass
-        WORKER_ENVIRONMENT_BLACKLIST: DOCKER_BUILDBOT* BUILDBOT_ENV_* BUILDBOT_1* WORKER_ENVIRONMENT_BLACKLIST
+      BUILDMASTER: buildbot
+      BUILDMASTER_PORT: 9989
+      WORKERNAME: example-worker
+      WORKERPASS: pass
+      WORKER_ENVIRONMENT_BLACKLIST: DOCKER_BUILDBOT* BUILDBOT_ENV_* BUILDBOT_1* WORKER_ENVIRONMENT_BLACKLIST
 
     links:
-        - buildbot
+      - buildbot


### PR DESCRIPTION
I noted when looking at the file that it was a bit messy because it used a mix of 2 and 4 spaces as indentation width in the YAML. [yamllint](https://github.com/adrienverge/yamllint) also showed warnings about the same things.

I cleaned the file up, so that the indentation would be harmonized and give people a better first impression of a great tool (=buildbot). ❤️ 