### PR TITLE
Amend twisted configuration

### DIFF
--- a/simple/docker-compose.yml
+++ b/simple/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - BUILDBOT_CONFIG_URL=https://github.com/buildbot/buildbot-docker-example-config/archive/master.tar.gz
       - BUILDBOT_WORKER_PORT=9989
       - BUILDBOT_WEB_URL=http://localhost:8010/
-      - BUILDBOT_WEB_PORT=8010
+      - BUILDBOT_WEB_PORT=tcp:port=8010
     links:
       - db
     depends_on:


### PR DESCRIPTION
It seems twisted wants to see the protocol as well, not just a bare port
number. Without this we got:

```
exceptions.ValueError: Unknown endpoint type: '8010'
```

fixes #11 