### PR TITLE
can run local master config file now with docker

### DIFF
--- a/pypy/master/start_buildbot.sh
+++ b/pypy/master/start_buildbot.sh
@@ -5,18 +5,21 @@
 # we download the config from an arbitrary curl accessible tar.gz file (which github can generate for us)
 
 B=`pwd`
+BUILDBOT_CONFIG_DIR=${BUILDBOT_CONFIG_DIR:-config}
 
 if [ -z "$BUILDBOT_CONFIG_URL" ]
 then
-    if [ ! -f "$B/master.cfg" ]
+    if [ ! -f "$B/$BUILDBOT_CONFIG_DIR/master.cfg" ]
     then
         echo No master.cfg found nor $$BUILDBOT_CONFIG_URL !
-        echo Please provide a master.cfg file in $B or provide a $$BUILDBOT_CONFIG_URL variable via -e
+        echo Please provide a master.cfg file in $B/$BUILDBOT_CONFIG_DIR or provide a $$BUILDBOT_CONFIG_URL variable via -e
         exit 1
     fi
+fi
 
-else
-    BUILDBOT_CONFIG_DIR=${BUILDBOT_CONFIG_DIR:-config}
+# if config is not downloaded, do it
+if [ -n "$BUILDBOT_CONFIG_URL" ]
+then
     mkdir -p $B/$BUILDBOT_CONFIG_DIR
     # if it ends with .tar.gz then its a tarball, else its directly the file
     if echo "$BUILDBOT_CONFIG_URL" | grep '.tar.gz$' >/dev/null
@@ -26,20 +29,21 @@ else
             echo "Can't download from \$BUILDBOT_CONFIG_URL: $BUILDBOT_CONFIG_URL"
             sleep 1
         done
-
-        ln -sf $B/$BUILDBOT_CONFIG_DIR/master.cfg $B/master.cfg
-
-        if [ -f $B/$BUILDBOT_CONFIG_DIR/buildbot.tac ]
-        then
-            ln -sf $B/$BUILDBOT_CONFIG_DIR/buildbot.tac $B/buildbot.tac
-        fi
     else
-        until curl -sL $BUILDBOT_CONFIG_URL > $B/master.cfg
+        until curl -sL $BUILDBOT_CONFIG_URL > $B/$BUILDBOT_CONFIG_DIR/master.cfg
         do
             echo "Can't download from $$BUILDBOT_CONFIG_URL: $BUILDBOT_CONFIG_URL"
         done
     fi
 fi
+
+# link downloaded/local files
+ln -sf $B/$BUILDBOT_CONFIG_DIR/master.cfg $B/master.cfg
+if [ -f $B/$BUILDBOT_CONFIG_DIR/buildbot.tac ]
+then
+    ln -sf $B/$BUILDBOT_CONFIG_DIR/buildbot.tac $B/buildbot.tac
+fi
+
 # copy the default buildbot.tac if not provided by the config
 if [ ! -f $B/buildbot.tac ]
 then


### PR DESCRIPTION
My personal flow is to create first local changes to the master.cfg file and after successful testing uploading it to a repo. With the current script it was not possible to do something like this.

I changed it to use a given config file from the BUILDBOT_CONFIG_DIR folder if existing.
the original behavior should still work.

in ./pypy/master/:
`docker build -t peterus/buildbot .`
in ./:
`docker run -v $PWD:/usr/src/app/config -p 8010:8010 peterus/buildbot`