### PR TITLE
BuildmasterConfig key 'status' is deprecated

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -80,13 +80,13 @@ c['builders'].append(
       workernames=["example-worker"],
       factory=factory))
 
-####### STATUS TARGETS
+####### REPORTER TARGETS
 
-# 'status' is a list of Status Targets. The results of each build will be
-# pushed to these targets. buildbot/status/*.py has a variety to choose from,
+# 'services' is a list of Reporter Targets. The results of each build will be
+# pushed to these targets. buildbot/reporters/*.py has a variety to choose from,
 # like IRC bots.
 
-c['status'] = []
+c['services'] = []
 
 ####### PROJECT IDENTITY
 


### PR DESCRIPTION
'status' key was removed in config.py which meant that the simple docker-compose demo no longer worked