### PR TITLE
Rename pollinterval argument to pollInterval

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -45,7 +45,7 @@ c['change_source'] = []
 c['change_source'].append(changes.GitPoller(
         'git://github.com/buildbot/pyflakes.git',
         workdir='gitpoller-workdir', branch='master',
-        pollinterval=300))
+        pollInterval=300))
 
 ####### SCHEDULERS
 


### PR DESCRIPTION
pollinterval is no longer available as of Buildbot 4.0.0